### PR TITLE
conditions for checking the giphy api key exist

### DIFF
--- a/lib/touch_craft_editor.dart
+++ b/lib/touch_craft_editor.dart
@@ -1002,7 +1002,7 @@ class _TouchCraftEditorState extends State<TouchCraftEditor> {
   /// if a gif is selected, it's added as an editable item to the stack data.
   /// Updates the state to reflect the new gif addition.
   void _onAddGifTap() async {
-    if (widget.giphyApiKey != null && widget.giphyApiKey != '') {
+    if (widget.giphyApiKey == null || widget.giphyApiKey!.isEmpty) {
       showDialog(
         context: context,
         barrierDismissible: true,
@@ -1146,7 +1146,7 @@ class _TouchCraftEditorState extends State<TouchCraftEditor> {
   }) async {
     _screenRecordingController.start();
     await Future.delayed(Duration(seconds: 3));
-    _screenRecordingController.stop();
+    _screenRecordingController.stop(); 
     final gif = await _screenRecordingController.exporter.exportGif();
     if (gif != null) {
       Uint8List bytes = Uint8List.fromList(gif);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the behavior when adding a GIF to show an alert if the API key is missing or empty, ensuring users are notified when the required key is not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->